### PR TITLE
Add nested Ladder subpage

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,9 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       node,
       trailingSlash: false,
       getNode,
-      basePath: `pages`
+      // Remove the `src/projects` prefix so nested project
+      // directories generate clean URLs like `/ladder/example`.
+      basePath: `src/projects`
     });
     createNodeField({
       node,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -67,7 +67,9 @@ exports.createPages = ({ graphql, actions }) => {
         let parentTitle = null;
         const parts = node.fields.slug.split('/').filter(Boolean);
         if (parts.length > 1) {
-          parentSlug = `/${parts[0]}/`;
+          // Use the first path segment as the parent slug. Do not include a
+          // trailing slash so it matches the slug created by `createFilePath`.
+          parentSlug = `/${parts[0]}`;
           const parent = posts.find(p => p.node.fields.slug === parentSlug);
           if (parent) {
             parentTitle = parent.node.frontmatter.title;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -63,6 +63,16 @@ exports.createPages = ({ graphql, actions }) => {
       const posts = result.data.allMarkdownRemark.edges;
 
       posts.forEach(({ node }, index) => {
+        let parentSlug = null;
+        let parentTitle = null;
+        const parts = node.fields.slug.split('/').filter(Boolean);
+        if (parts.length > 1) {
+          parentSlug = `/${parts[0]}/`;
+          const parent = posts.find(p => p.node.fields.slug === parentSlug);
+          if (parent) {
+            parentTitle = parent.node.frontmatter.title;
+          }
+        }
         createPage({
           path: node.fields.slug,
           component: path.resolve(`./src/templates/blog-post.js`),
@@ -70,7 +80,9 @@ exports.createPages = ({ graphql, actions }) => {
             prev: index === 0 ? false : posts[index - 1].node,
             next: index === posts.length - 1 ? false : posts[index + 1].node,
             // Data passed to context is available in page queries as GraphQL variables.
-            slug: node.fields.slug
+            slug: node.fields.slug,
+            parentTitle,
+            parentSlug
           }
         });
       });

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -25,16 +25,16 @@ class Nav extends Component<NavProps> {
         <p>
           <Link to="/">Sam Chang</Link>
           {parentTitle && parentSlug && (
-            <>
+            <span>
               {" / "}
               <Link to={parentSlug}>{parentTitle}</Link>
-            </>
+            </span>
           )}
           {title && (
-            <>
+            <span>
               {" / "}
               {title}
-            </>
+            </span>
           )}
         </p>{" "}
         <p />

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -10,13 +10,32 @@ const NavStyled = styled.div`
   display: inline-block;
 `;
 
-class Nav extends Component {
+interface NavProps {
+  title?: string;
+  parentTitle?: string;
+  parentSlug?: string;
+}
+
+class Nav extends Component<NavProps> {
   render() {
+    const { title, parentTitle, parentSlug } = this.props as NavProps;
+
     return (
       <NavStyled>
         <p>
           <Link to="/">Sam Chang</Link>
-          {this.props.title ? " / " + this.props.title : null}
+          {parentTitle && parentSlug && (
+            <>
+              {" / "}
+              <Link to={parentSlug}>{parentTitle}</Link>
+            </>
+          )}
+          {title && (
+            <>
+              {" / "}
+              {title}
+            </>
+          )}
         </p>{" "}
         <p />
       </NavStyled>

--- a/src/projects/ladder/sample-project/index.md
+++ b/src/projects/ladder/sample-project/index.md
@@ -4,6 +4,10 @@ date: "2024"
 customField: VALUE_1
 section: blog
 excerpt: An example nested page under Ladder.
+image1: "../images/img_homepage_01.png"
+image2: "../images/img_FPF.png"
+image3: "../images/img_transparency_01.png"
+image4: "../images/img_affordability.png"
 ---
 
 # Sample Project

--- a/src/projects/ladder/sample-project/index.md
+++ b/src/projects/ladder/sample-project/index.md
@@ -1,0 +1,11 @@
+---
+title: Sample Project
+date: "2024"
+customField: VALUE_1
+section: blog
+excerpt: An example nested page under Ladder.
+---
+
+# Sample Project
+
+This is a placeholder page demonstrating nested content within the Ladder section.

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -106,7 +106,11 @@ const BlogPostTemplate = ({ data, pageContext }) => {
         ]}
       />
       <Header>
-        <Nav title={post.frontmatter.title} />
+        <Nav
+          title={post.frontmatter.title}
+          parentTitle={pageContext.parentTitle}
+          parentSlug={pageContext.parentSlug}
+        />
         <Menu />
       </Header>
       <ContentWrapper>
@@ -140,6 +144,9 @@ export const query = graphql`
   query BlogPostQuery($slug: String!) {
     markdownRemark(fields: { slug: { eq: $slug } }) {
       htmlAst
+      fields {
+        slug
+      }
       frontmatter {
         title
       }


### PR DESCRIPTION
## Summary
- generate slugs relative to `src/projects` so nested project directories become nested URLs
- add a sample Ladder subpage showing the structure for nested project pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68437d7eda34832dbce47963c7522cb6