### PR TITLE
Fix case for Link in renderAst mapping

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -38,6 +38,7 @@ const renderAst = new RehypeReact({
     gif: GIF,
     ul: UnorderedList,
     ol: OrderedList,
+    link: Link,
     "blog-button": BlogButton,
     "button-visit": Button,
     "content-title": ContentTitle,


### PR DESCRIPTION
## Summary
- use lowercase key for Link in blog post renderer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684738634b04832d82d95bc5fbd96786