### PR TITLE
Add content validation tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,10 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
-  testMatch: ['**/tests/**/*.(test|spec).ts?(x)']
+  testMatch: ['**/tests/**/*.test.ts?(x)', '**/tests/**/*.spec.ts?(x)'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json'
+    }
+  }
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  testMatch: ['**/tests/**/*.(test|spec).ts?(x)']
+};

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "lint": "tslint --project .",
-    "test": "echo 'Run your tests here'"
+    "test": "jest && node tests/validate-content.js"
   },
   "devDependencies": {
     "@types/react": "^17.0.15",
@@ -69,7 +69,12 @@
     "husky": "^7.0.1",
     "lint-staged": "^11.1.1",
     "prettier": "^2.3.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.3.5",
+    "@types/jest": "^29.5.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^5.16.5",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0"
   },
   "repository": {
     "type": "git",

--- a/tests/Menu.test.tsx
+++ b/tests/Menu.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Menu from '../src/components/Menu';
+
+jest.mock('gatsby', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  )
+}));
+
+describe('Menu component', () => {
+  test('renders menu button', () => {
+    render(<Menu />);
+    expect(screen.getByRole('button', { name: /menu/i })).toBeInTheDocument();
+  });
+});

--- a/tests/validate-content.js
+++ b/tests/validate-content.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+
+let failed = false;
+function fail(msg) {
+  console.error(msg);
+  failed = true;
+}
+
+// Validate project markdown frontmatter
+const projectsDir = path.join(__dirname, '..', 'src', 'projects');
+if (fs.existsSync(projectsDir)) {
+  const projects = fs.readdirSync(projectsDir).filter(d => fs.statSync(path.join(projectsDir, d)).isDirectory());
+  projects.forEach(project => {
+    const file = path.join(projectsDir, project, 'index.md');
+    if (!fs.existsSync(file)) {
+      fail(`Missing index.md in ${project}`);
+      return;
+    }
+    const content = fs.readFileSync(file, 'utf8');
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) {
+      fail(`Missing frontmatter in ${file}`);
+      return;
+    }
+    const data = {};
+    match[1].split('\n').forEach(line => {
+      const idx = line.indexOf(':');
+      if (idx !== -1) {
+        const key = line.slice(0, idx).trim();
+        const value = line.slice(idx + 1).trim().replace(/^"|"$/g, '');
+        data[key] = value;
+      }
+    });
+    ['title', 'date', 'excerpt'].forEach(field => {
+      if (!data[field]) fail(`${file} is missing ${field}`);
+    });
+  });
+}
+
+// Validate music JSON data
+const musicPath = path.join(__dirname, '..', 'data', 'music', 'music.json');
+if (fs.existsSync(musicPath)) {
+  try {
+    const music = JSON.parse(fs.readFileSync(musicPath, 'utf8'));
+    if (!Array.isArray(music)) {
+      fail('Music data is not an array');
+    } else {
+      music.forEach((item, idx) => {
+        ['title', 'date', 'url'].forEach(field => {
+          if (!item[field]) fail(`music[${idx}].${field} missing`);
+        });
+        if (!item.image || !item.image.src) {
+          fail(`music[${idx}].image.src missing`);
+        }
+      });
+    }
+  } catch (e) {
+    fail(`Music JSON parse error: ${e.message}`);
+  }
+}
+
+if (failed) {
+  console.error('Content validation failed');
+  process.exit(1);
+} else {
+  console.log('Content validation passed');
+}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Summary
- add script to validate Markdown frontmatter and music JSON
- run the validation with `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68475279a6e4832da6b11266591f116d