### PR TITLE
Implement controller-only mouse mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ SPOTIFY_REFRESH_TOKEN=your_refresh_token
 ```
 
 These values are used by `api/now-playing.js` to query Spotify's API.
+
+## Remote Mouse Mirroring
+
+Run the WebSocket server:
+```bash
+npm start
+```
+
+In a separate terminal run Gatsby:
+```bash
+gatsby develop
+```
+Open multiple tabs at `localhost:8000` to see ghost cursors following other visitors.

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,15 @@
+import React from "react";
 import { inject } from "@vercel/analytics";
+import RemoteCursor from "./src/components/RemoteCursor";
 
 // Inject Vercel Analytics
 export const onInitialClientRender = () => {
   inject();
 };
+
+export const wrapRootElement = ({ element }) => (
+  <>
+    {element}
+    <RemoteCursor />
+  </>
+);

--- a/package.json
+++ b/package.json
@@ -51,13 +51,15 @@
     "serialize-javascript": "^6.0.0",
     "set-value": "^4.1.0",
     "sharp": "^0.31.2",
-    "throttle-debounce": "^5.0.0"
+    "throttle-debounce": "^5.0.0",
+    "ws": "^8.13.0"
   },
   "keywords": [
     "gatsby"
   ],
   "license": "MIT",
   "scripts": {
+    "start": "node server.js",
     "type-check": "tsc --noEmit",
     "lint": "tslint --project .",
     "test": "jest && node tests/validate-content.js"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,25 @@
+const WebSocket = require('ws');
+
+const PORT = process.env.PORT || 8080;
+const wss = new WebSocket.Server({ port: PORT });
+
+const clients = new Set();
+
+wss.on('connection', (ws) => {
+  clients.add(ws);
+
+  ws.on('message', (data) => {
+    for (const client of clients) {
+      if (client !== ws && client.readyState === WebSocket.OPEN) {
+        client.send(data);
+      }
+    }
+  });
+
+  ws.on('close', () => {
+    clients.delete(ws);
+  });
+});
+
+console.log(`WebSocket server running at ws://localhost:${PORT}`);
+

--- a/src/components/RemoteCursor/index.tsx
+++ b/src/components/RemoteCursor/index.tsx
@@ -1,0 +1,77 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/react';
+import styled from '@emotion/styled';
+import { useEffect, useRef } from 'react';
+import { throttle } from 'throttle-debounce';
+
+// Test locally by running `gatsby develop` and opening two tabs:
+// one with `?controller=true` to broadcast, and another without to view.
+
+export const WS_SERVER = 'ws://localhost:8080';
+
+const Cursor = styled.div`
+  pointer-events: none;
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  margin-left: -16px;
+  margin-top: -16px;
+  border-radius: 50%;
+  background: rgba(0, 125, 255, 0.4);
+  transition: transform 0.08s linear;
+  z-index: 10000;
+`;
+
+export default function RemoteCursor() {
+  const cursorRef = useRef<HTMLDivElement>(null);
+  const socketRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const isController =
+      new URLSearchParams(window.location.search).get('controller') === 'true';
+
+    const socket = new WebSocket(WS_SERVER);
+    socketRef.current = socket;
+
+    const sendPosition = throttle(16, (x: number, y: number) => {
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ x, y }));
+      }
+    });
+
+    const handleMove = (e: MouseEvent) => {
+      if (isController) {
+        sendPosition(e.clientX, e.clientY);
+      }
+    };
+
+    if (isController) {
+      window.addEventListener('mousemove', handleMove);
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      try {
+        const { x, y } = JSON.parse(event.data);
+        const node = cursorRef.current;
+        if (node) {
+          node.style.transform = `translate(${x}px, ${y}px)`;
+        }
+      } catch (err) {
+        // ignore invalid messages
+      }
+    };
+
+    socket.addEventListener('message', handleMessage);
+
+    return () => {
+      if (isController) {
+        window.removeEventListener('mousemove', handleMove);
+      }
+      socket.removeEventListener('message', handleMessage);
+      socket.close();
+    };
+  }, []);
+
+  return <Cursor ref={cursorRef} />;
+}
+


### PR DESCRIPTION
## Summary
- adjust RemoteCursor so only `?controller=true` sends mouse positions
- add comment explaining how to test with multiple tabs

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6848b6009934832d83982a71130b094b