### PR TITLE
Add persistent global chatbot

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,0 @@
-import { inject } from "@vercel/analytics";
-
-// Inject Vercel Analytics
-export const onInitialClientRender = () => {
-  inject();
-};

--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { inject } from "@vercel/analytics";
+import PortfolioChatBot from "./src/components/PortfolioChatBot";
+
+// Inject Vercel Analytics
+export const onInitialClientRender = () => {
+  inject();
+};
+
+export const wrapRootElement = ({ element }: { element: React.ReactNode }) => (
+  <>
+    {element}
+    <PortfolioChatBot />
+  </>
+);

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -28,7 +28,6 @@ import { Helmet } from "react-helmet";
 import defaultTheme from "../components/Theme";
 
 // ✅ Add these imports
-import PortfolioChatBot from "../components/PortfolioChatBot";
 import { projectSummaries } from "../../lib/projectSummaries";
 
 
@@ -146,8 +145,7 @@ const BlogPostTemplate = ({ data, pageContext }) => {
         </Footer>
       </ContentWrapper>
 
-      {/* ✅ Mount the chatbot only if this is a project */}
-      <PortfolioChatBot projectSlug={slug} />
+      {/* Chatbot mounted globally */}
     </Page>
   );
 };


### PR DESCRIPTION
## Summary
- make PortfolioChatBot draggable and persist history to localStorage
- mount chatbot once with `wrapRootElement`
- remove per‑page mounts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba93a5c14832dbb503a005f6512d2