### PR TITLE
Add zoomable images

### DIFF
--- a/src/components/ZoomImage/index.tsx
+++ b/src/components/ZoomImage/index.tsx
@@ -1,0 +1,45 @@
+/** @jsx jsx */
+import React, { useState } from "react";
+import { jsx, css } from "@emotion/react";
+
+const overlayStyle = css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: zoom-out;
+  z-index: 1000;
+`;
+
+const zoomedImageStyle = css`
+  max-width: 90%;
+  max-height: 90%;
+`;
+
+const ZoomImage: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = (props) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <img
+        {...props}
+        onClick={() => setOpen(true)}
+        css={css`
+          cursor: zoom-in;
+        `}
+      />
+      {open && (
+        <div css={overlayStyle} onClick={() => setOpen(false)}>
+          <img {...props} css={zoomedImageStyle} />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ZoomImage;

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -30,6 +30,7 @@ import defaultTheme from "../components/Theme";
 // ✅ Add these imports
 import { ClickablePrompt } from "../components/ChatBot";
 import PromptContainer from "../components/Blog/PromptContainer";
+import ZoomImage from "../components/ZoomImage";
 
 const renderAst = new RehypeReact({
   createElement: React.createElement,
@@ -47,6 +48,7 @@ const renderAst = new RehypeReact({
     Button: Button,
     link: Link,
     Link: Link,
+    img: ZoomImage,
     "content-title": ContentTitle,
     "content-excerpt": ContentExcerpt,
     summary: Summary,


### PR DESCRIPTION
## Summary
- make images zoomable in markdown
- map `img` tags to the new ZoomImage component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858707e5814832dacab2beba5e4941c